### PR TITLE
Use double quotes for selecting a value

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ This is done using the `_` argument, which takes a value.
 GraphQL:
 ```graphql
 {
-  name(_:'Han Solo')
+  name(_:"Han Solo")
   description
 }
 ```


### PR DESCRIPTION
I got an error that double quotes should be used instead of single quotes. This PR updates the README.